### PR TITLE
Update azure-blob-storage-upload.html

### DIFF
--- a/azure-blob-storage-upload.html
+++ b/azure-blob-storage-upload.html
@@ -99,6 +99,10 @@
             <span class="property-type"> boolean </span>
         </dt>
         <dd>A date string representing when the uploading happens.</dd>
+        <dt class="optional"> msg.blobName
+            <span class="property-type"> string </span>
+        </dt>
+        <dd>A string to optionally overwrite the configured blob name.</dd>
     </dl>
 
     <h3>Details</h3>


### PR DESCRIPTION
Update the upload node's help text displayed in the info tab to include information on setting the optional property `msg.blobName`  to overwrite the configured name.